### PR TITLE
Run effects concurrently not sequentially

### DIFF
--- a/content/archived/run-effects-in-parallel-with-all.mdx
+++ b/content/archived/run-effects-in-parallel-with-all.mdx
@@ -51,7 +51,7 @@ const fetchPosts = Effect.succeed([{ title: "Effect is great" }]).pipe(
 );
 
 // Run both effects concurrently
-const program = Effect.all([fetchUser, fetchPosts]);
+const program = Effect.all([fetchUser, fetchPosts], { concurrency: "unbounded" });
 
 // The resulting effect will succeed with a tuple: [{id, name}, [{title}]]
 // Total execution time will be ~1.5 seconds (the duration of the longest task).

--- a/content/published/run-effects-in-parallel-with-all.mdx
+++ b/content/published/run-effects-in-parallel-with-all.mdx
@@ -51,7 +51,7 @@ const fetchPosts = Effect.succeed([{ title: "Effect is great" }]).pipe(
 );
 
 // Run both effects concurrently
-const program = Effect.all([fetchUser, fetchPosts]);
+const program = Effect.all([fetchUser, fetchPosts], { concurrency: "unbounded" });
 
 // The resulting effect will succeed with a tuple: [{id, name}, [{title}]]
 // Total execution time will be ~1.5 seconds (the duration of the longest task).

--- a/content/src/run-effects-in-parallel-with-all.ts
+++ b/content/src/run-effects-in-parallel-with-all.ts
@@ -11,7 +11,7 @@ const fetchPosts = Effect.succeed([{ title: "Effect is great" }]).pipe(
 );
 
 // Run both effects concurrently
-const program = Effect.all([fetchUser, fetchPosts]);
+const program = Effect.all([fetchUser, fetchPosts], { concurrency: "unbounded" });
 
 // The resulting effect will succeed with a tuple: [{id, name}, [{title}]]
 // Total execution time will be ~1.5 seconds (the duration of the longest task).

--- a/rules/by-use-case/concurrency.md
+++ b/rules/by-use-case/concurrency.md
@@ -699,7 +699,7 @@ const fetchPosts = Effect.succeed([{ title: "Effect is great" }]).pipe(
 );
 
 // Run both effects concurrently
-const program = Effect.all([fetchUser, fetchPosts]);
+const program = Effect.all([fetchUser, fetchPosts], { concurrency: "unbounded" });
 
 // The resulting effect will succeed with a tuple: [{id, name}, [{title}]]
 // Total execution time will be ~1.5 seconds (the duration of the longest task).

--- a/rules/intermediate.md
+++ b/rules/intermediate.md
@@ -2519,7 +2519,7 @@ const fetchPosts = Effect.succeed([{ title: "Effect is great" }]).pipe(
 );
 
 // Run both effects concurrently
-const program = Effect.all([fetchUser, fetchPosts]);
+const program = Effect.all([fetchUser, fetchPosts], { concurrency: "unbounded" });
 
 // The resulting effect will succeed with a tuple: [{id, name}, [{title}]]
 // Total execution time will be ~1.5 seconds (the duration of the longest task).

--- a/rules/rules.md
+++ b/rules/rules.md
@@ -6502,7 +6502,7 @@ const fetchPosts = Effect.succeed([{ title: "Effect is great" }]).pipe(
 );
 
 // Run both effects concurrently
-const program = Effect.all([fetchUser, fetchPosts]);
+const program = Effect.all([fetchUser, fetchPosts], { concurrency: "unbounded" });
 
 // The resulting effect will succeed with a tuple: [{id, name}, [{title}]]
 // Total execution time will be ~1.5 seconds (the duration of the longest task).


### PR DESCRIPTION
Hello its me again,

Effect.all runs all the effects sequentially by default, to run them concurrently we need to set the concurrency option.