### PR TITLE
fix: resolve 404 on root endpoint (issue #78)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
-  "buildCommand": "npm install --legacy-peer-deps",
+  "installCommand": "bun install",
+  "buildCommand": "cd packages/toolkit && bun run build",
   "builds": [
     {
       "src": "api/index.ts",
@@ -8,6 +9,10 @@
     }
   ],
   "routes": [
+    {
+      "src": "/",
+      "dest": "/api/index.ts"
+    },
     {
       "src": "/health",
       "dest": "/api/index.ts"


### PR DESCRIPTION
## Problem

The root endpoint `https://effect-patterns.vercel.app/` was returning a 404 error, despite having a handler implemented in `api/index.ts` that should return API documentation.

References: #43 (closed), #78 (reopened with same issue)

## Root Cause

The `vercel.json` configuration was missing an explicit route mapping for the root path (`/`). While the `api/index.ts` handler had the logic to handle the root request (lines 225-240), Vercel wasn't routing requests to that handler.

Additionally, the build configuration was using `npm install` instead of `bun install`, which could cause dependency resolution issues in the monorepo.

## Solution

1. **Add root route mapping**: Added `{ "src": "/", "dest": "/api/index.ts" }` to route requests to the handler
2. **Update build config**: Changed from `npm install` to `bun install` for consistency with the monorepo
3. **Add toolkit build**: Ensured the toolkit is built before deployment

## Changes Made

- Updated `vercel.json`:
  - Added explicit "/" route
  - Changed `installCommand` to use `bun`
  - Updated `buildCommand` to build toolkit first
  - Now routes: `/` → handler returning API docs (JSON)
  - Existing routes continue to work: `/health`, `/api/v1/rules`, etc.

## Result

After deployment:
- `GET https://effect-patterns.vercel.app/` → Returns API documentation (200 OK)
- `GET https://effect-patterns.vercel.app/health` → Returns health check (200 OK)
- `GET https://effect-patterns.vercel.app/api/v1/rules` → Returns all rules (200 OK)

## Testing

Once merged and deployed:
```bash
# Should return API documentation with endpoints listed
curl https://effect-patterns.vercel.app/

# Should return health status  
curl https://effect-patterns.vercel.app/health
```

Closes #78

🤖 Generated with Claude Code