### PR TITLE
feat(schema): JSON DB Validation patterns

### DIFF
--- a/patterns/schema/json-db-validation/basic.md
+++ b/patterns/schema/json-db-validation/basic.md
@@ -1,0 +1,168 @@
+---
+id: schema-json-db-basic
+title: Validating JSON Database Columns
+category: json-db-validation
+skill: beginner
+tags:
+  - schema
+  - database
+  - json
+  - validation
+  - type-safety
+---
+
+# Problem
+
+Databases store JSON data in columns (MySQL JSON, PostgreSQL JSONB, SQLite JSON), but the database itself doesn't enforce schema—any JSON is valid from the database's perspective. When you retrieve JSON from a database, it's untyped and could contain incorrect fields, wrong data types, or missing required values. You need to validate the JSON immediately after retrieval to ensure data integrity and prevent runtime errors downstream in your application.
+
+# Solution
+
+```typescript
+import { Schema, Effect } from "effect";
+
+// 1. Define schema for database JSON column
+const UserMetadata = Schema.Struct({
+  theme: Schema.Literal("light", "dark", "auto").pipe(
+    Schema.optionalWith({ default: () => "auto" })
+  ),
+  notifications: Schema.Boolean.pipe(
+    Schema.optionalWith({ default: () => true })
+  ),
+  language: Schema.Literal("en", "es", "fr", "de").pipe(
+    Schema.optionalWith({ default: () => "en" })
+  ),
+  lastLogin: Schema.String.pipe(
+    Schema.pattern(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
+  ).pipe(Schema.optional),
+  preferences: Schema.Struct({
+    compactView: Schema.Boolean,
+    showGuidance: Schema.Boolean,
+  }).pipe(Schema.optional),
+});
+
+type UserMetadata = typeof UserMetadata.Type;
+
+// 2. Simulate database retrieval
+const mockDatabaseQuery = (userId: string): unknown =>
+  JSON.parse(`
+    {
+      "theme": "dark",
+      "notifications": true,
+      "language": "en",
+      "lastLogin": "2024-12-17T10:30:00Z",
+      "preferences": {
+        "compactView": true,
+        "showGuidance": false
+      }
+    }
+  `);
+
+// 3. Validate JSON from database
+const validateMetadataFromDb = (userId: string) =>
+  Effect.gen(function* () {
+    // 1. Query database (returns unknown)
+    const rawData = yield* Effect.sync(() =>
+      mockDatabaseQuery(userId)
+    );
+
+    // 2. Validate against schema
+    const metadata = yield* Schema.decodeUnknown(UserMetadata)(
+      rawData
+    ).pipe(
+      Effect.mapError((error) => ({
+        _tag: "ValidationError" as const,
+        userId,
+        message: `Invalid user metadata: ${error.message}`,
+      }))
+    );
+
+    return metadata;
+  });
+
+// 4. Usage: Fetch and validate user metadata
+Effect.runPromise(validateMetadataFromDb("user-123"))
+  .then((metadata) => {
+    console.log("✅ Metadata loaded:");
+    console.log(`  Theme: ${metadata.theme}`);
+    console.log(`  Notifications: ${metadata.notifications}`);
+    console.log(`  Language: ${metadata.language}`);
+    console.log(
+      `  Last Login: ${metadata.lastLogin ?? "never"}`
+    );
+    if (metadata.preferences) {
+      console.log(
+        `  Compact View: ${metadata.preferences.compactView}`
+      );
+    }
+  })
+  .catch((error) => {
+    console.error(`❌ ${error._tag}: ${error.message}`);
+  });
+
+// 5. Type-safe access to validated data
+const applyUserTheme = (metadata: UserMetadata): string => {
+  // These properties are guaranteed to exist with correct types
+  // No undefined checks needed
+  switch (metadata.theme) {
+    case "light":
+      return "/* light theme styles */";
+    case "dark":
+      return "/* dark theme styles */";
+    case "auto":
+      return "/* auto-detect theme */";
+  }
+};
+
+// 6. Database retrieval with multiple rows
+const validateMultipleMetadata = (userIds: string[]) =>
+  Effect.gen(function* () {
+    const results = yield* Effect.all(
+      userIds.map((userId) =>
+        validateMetadataFromDb(userId).pipe(
+          Effect.catchAll((error) =>
+            Effect.succeed({
+              userId,
+              valid: false,
+              error: error.message,
+            } as const)
+          )
+        )
+      )
+    );
+
+    const valid = results.filter((r) => "theme" in r);
+    const invalid = results.filter((r) => !("theme" in r));
+
+    return { valid, invalid };
+  });
+```
+
+# Why This Works
+
+| Concept | Explanation |
+|---------|-------------|
+| Schema as contract | Define shape of JSON before retrieving from DB |
+| `Schema.decodeUnknown()` | Convert untyped database JSON to typed data |
+| Error channel | Validation failures don't throw; flow through Effect |
+| Defaults via `optionalWith` | Apply missing-field defaults at parse time |
+| Type-safe after validation | TypeScript knows validated data matches schema |
+| Immediate validation | Catch bad data at DB boundary, not downstream |
+| Composable schemas | Nested structures validated automatically |
+
+# When to Use
+
+- Retrieving JSON columns from PostgreSQL, MySQL, SQLite
+- User preferences/settings stored as JSON in database
+- Metadata columns that should follow a specific structure
+- Audit logs or event data stored as JSON
+- API responses cached in database as JSON
+- Validating data immediately after database queries
+- Preventing downstream code from dealing with bad database data
+- Type-safe database record processing
+
+# Related Patterns
+
+- [Basic JSON File Validation](../json-file-validation/basic.md)
+- [PostgreSQL JSONB Validation](./postgres-jsonb.md)
+- [Handling Schema Evolution](./schema-evolution.md)
+- [Validating Partial Documents](./partial-validation.md)

--- a/patterns/schema/json-db-validation/partial-validation.md
+++ b/patterns/schema/json-db-validation/partial-validation.md
@@ -1,0 +1,301 @@
+---
+id: schema-json-db-partial-validation
+title: Validating Partial Documents
+category: json-db-validation
+skill: intermediate
+tags:
+  - schema
+  - database
+  - json
+  - partial
+  - patch
+---
+
+# Problem
+
+REST APIs support PATCH requests that update only specific fields—users don't send the entire document, just the fields they want to change. But you still need to validate those fields against your schema. Using the same schema for PATCH and PUT leads to "field is required" errors on optional updates. You need a way to validate only the fields that are present, ignoring missing ones, while still enforcing constraints on the fields that are included.
+
+# Solution
+
+```typescript
+import { Schema, Effect } from "effect";
+
+// 1. Define full document schema
+const ProductSchema = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String.pipe(Schema.minLength(1)),
+  description: Schema.String.pipe(Schema.minLength(10)),
+  price: Schema.Number.pipe(Schema.positive()),
+  stock: Schema.Number.pipe(Schema.int(), Schema.between(0, 10000)),
+  category: Schema.Literal(
+    "electronics",
+    "clothing",
+    "books",
+    "other"
+  ),
+  active: Schema.Boolean,
+});
+
+type Product = typeof ProductSchema.Type;
+
+// 2. Create partial schema (all fields optional)
+const ProductPatchSchema = Schema.partial(ProductSchema);
+
+type ProductPatch = typeof ProductPatchSchema.Type;
+
+// 3. Validate full product (PUT)
+const validateFullProduct = (input: unknown) =>
+  Effect.gen(function* () {
+    const product = yield* Schema.decodeUnknown(ProductSchema)(
+      input
+    ).pipe(
+      Effect.mapError((error) => ({
+        _tag: "ProductValidationError" as const,
+        message: `Product data invalid: ${error.message}`,
+      }))
+    );
+
+    return product;
+  });
+
+// 4. Validate partial product (PATCH)
+const validateProductPatch = (input: unknown) =>
+  Effect.gen(function* () {
+    const patch = yield* Schema.decodeUnknown(
+      ProductPatchSchema
+    )(input).pipe(
+      Effect.mapError((error) => ({
+        _tag: "PatchValidationError" as const,
+        message: `Patch data invalid: ${error.message}`,
+      }))
+    );
+
+    // Ensure at least one field is present
+    if (Object.keys(patch).length === 0) {
+      return yield* Effect.fail({
+        _tag: "EmptyPatchError" as const,
+        message: "Patch must include at least one field",
+      });
+    }
+
+    return patch;
+  });
+
+// 5. Apply patch to existing product
+const applyProductPatch = (
+  existing: Product,
+  patch: ProductPatch
+) =>
+  Effect.gen(function* () {
+    // Merge patch with existing (only override provided fields)
+    const updated: Product = {
+      ...existing,
+      ...Object.fromEntries(
+        Object.entries(patch).filter(
+          ([, v]) => v !== undefined
+        )
+      ),
+    };
+
+    // Re-validate full product after patch
+    const validated = yield* validateFullProduct(updated);
+
+    return validated;
+  });
+
+// 6. Database operations with partial validation
+const updateProductInDb = (
+  productId: string,
+  patch: unknown
+) =>
+  Effect.gen(function* () {
+    console.log(`📝 Validating PATCH for product ${productId}`);
+
+    // 1. Validate patch structure
+    const validatedPatch = yield* validateProductPatch(patch);
+
+    // 2. Fetch existing product (simulated)
+    const existing: Product = {
+      id: productId,
+      name: "Original Product",
+      description:
+        "This is the original product description",
+      price: 99.99,
+      stock: 100,
+      category: "electronics",
+      active: true,
+    };
+
+    // 3. Apply patch
+    const updated = yield* applyProductPatch(
+      existing,
+      validatedPatch
+    );
+
+    console.log(`✅ Patch applied successfully`);
+    return updated;
+  });
+
+// 7. Batch partial updates with error handling
+const batchUpdateProducts = (
+  updates: Array<{ id: string; patch: unknown }>
+) =>
+  Effect.gen(function* () {
+    console.log(`\n🔄 Processing ${updates.length} updates...\n`);
+
+    const results = yield* Effect.all(
+      updates.map(({ id, patch }) =>
+        updateProductInDb(id, patch).pipe(
+          Effect.catchAll((error) =>
+            Effect.succeed({
+              id,
+              success: false,
+              error: error.message,
+            } as const)
+          )
+        )
+      )
+    );
+
+    const successful = results.filter(
+      (r) => "name" in r
+    );
+    const failed = results.filter((r) => !("name" in r));
+
+    return { successful, failed };
+  });
+
+// 8. Selective field updates
+const updateProductName = (
+  productId: string,
+  newName: string
+) =>
+  Effect.gen(function* () {
+    // Minimal patch - only one field
+    const patch = { name: newName };
+
+    const updated = yield* updateProductInDb(
+      productId,
+      patch
+    );
+    return updated;
+  });
+
+// 9. Complex partial update with validation
+const complexProductUpdate = (
+  productId: string,
+  patch: unknown
+) =>
+  Effect.gen(function* () {
+    // 1. Validate patch format
+    const validated = yield* validateProductPatch(patch);
+
+    // 2. Log what's changing
+    const changedFields = Object.keys(validated);
+    console.log(
+      `📋 Fields to update: ${changedFields.join(", ")}`
+    );
+
+    // 3. Check for conflicting updates
+    if (
+      validated.stock !== undefined &&
+      validated.stock < 0
+    ) {
+      return yield* Effect.fail({
+        _tag: "BusinessLogicError" as const,
+        message: "Stock cannot be negative",
+      });
+    }
+
+    // 4. Apply patch
+    const existing: Product = {
+      id: productId,
+      name: "Product",
+      description: "A great product",
+      price: 49.99,
+      stock: 50,
+      category: "other",
+      active: true,
+    };
+
+    const updated = yield* applyProductPatch(
+      existing,
+      validated
+    );
+
+    console.log(`✅ Product updated successfully`);
+    return updated;
+  });
+
+// 10. Usage: Different types of patches
+Effect.runPromise(
+  Effect.gen(function* () {
+    console.log(
+      "🛍️  Product PATCH Validation\n"
+    );
+
+    // Update just the name
+    yield* updateProductName("prod-1", "New Product Name");
+
+    // Complex update with multiple fields
+    yield* complexProductUpdate("prod-2", {
+      price: 79.99,
+      stock: 150,
+      category: "books",
+    });
+
+    // Batch updates with partial data
+    const results = yield* batchUpdateProducts([
+      { id: "prod-3", patch: { price: 49.99 } },
+      { id: "prod-4", patch: { active: false } },
+      { id: "prod-5", patch: { name: "", description: "x" } }, // This will fail validation
+      { id: "prod-6", patch: {} }, // Empty patch (will fail)
+    ]);
+
+    console.log(
+      `\n✅ Updated ${results.successful.length} products`
+    );
+    if (results.failed.length > 0) {
+      console.log(
+        `⚠️  ${results.failed.length} updates failed`
+      );
+    }
+  })
+)
+  .catch((error) => {
+    console.error(
+      `❌ Error: ${error.message}`
+    );
+  });
+```
+
+# Why This Works
+
+| Concept | Explanation |
+|---------|-------------|
+| `Schema.partial()` | Makes all fields optional while keeping type constraints |
+| PATCH vs PUT | Different validation strategies for full vs partial updates |
+| Field merging | Only updated fields override existing values |
+| Re-validation | Full document valid after patch applied |
+| Empty guard | Prevent meaningless empty patches |
+| Batch operations | Handle multiple partial updates efficiently |
+| Error granularity | Know exactly which fields failed validation |
+| Type-safe merging | Updated document has full type after validation |
+
+# When to Use
+
+- REST APIs supporting PATCH requests
+- Partial document updates (not full replacements)
+- Form submissions that update only changed fields
+- Database PATCH operations on JSON columns
+- Gradual data updates where only some fields change
+- User preference updates (only changed settings)
+- Configuration updates (only modified settings)
+- Preventing unnecessary database writes (only changed fields)
+
+# Related Patterns
+
+- [Validating JSON Database Columns](./basic.md)
+- [PostgreSQL JSONB Validation](./postgres-jsonb.md)
+- [Handling Schema Evolution](./schema-evolution.md)
+- [Dependent Field Validation](../form-validation/dependent-fields.md)

--- a/patterns/schema/json-db-validation/postgres-jsonb.md
+++ b/patterns/schema/json-db-validation/postgres-jsonb.md
@@ -1,0 +1,255 @@
+---
+id: schema-json-db-postgres-jsonb
+title: PostgreSQL JSONB Validation
+category: json-db-validation
+skill: intermediate
+tags:
+  - schema
+  - database
+  - postgresql
+  - jsonb
+  - validation
+---
+
+# Problem
+
+PostgreSQL JSONB columns are powerful and flexible, but that flexibility is dangerous. You can store any JSON, but your application expects specific fields with specific types. When you query JSONB columns and extract values, they're untyped and need validation. You also need to distinguish between stored data and data you're about to store—validating before INSERT/UPDATE is different from validating after SELECT. Plus, JSONB queries need to handle null and missing fields gracefully.
+
+# Solution
+
+```typescript
+import { Schema, Effect } from "effect";
+
+// 1. Define schema for JSONB document
+const OrderMetadata = Schema.Struct({
+  // Required fields
+  orderId: Schema.String,
+  customerId: Schema.String,
+  status: Schema.Literal(
+    "pending",
+    "processing",
+    "shipped",
+    "delivered",
+    "cancelled"
+  ),
+
+  // Optional tracking data
+  trackingNumber: Schema.String.pipe(Schema.optional),
+  estimatedDelivery: Schema.String.pipe(
+    Schema.pattern(/^\d{4}-\d{2}-\d{2}$/)
+  ).pipe(Schema.optional),
+
+  // Nested JSONB structure
+  items: Schema.Array(
+    Schema.Struct({
+      productId: Schema.String,
+      quantity: Schema.Number.pipe(
+        Schema.int(),
+        Schema.positive()
+      ),
+      price: Schema.Number.pipe(Schema.positive()),
+    })
+  ).pipe(Schema.minItems(1)),
+
+  // Metadata with defaults
+  source: Schema.Literal("web", "mobile", "api").pipe(
+    Schema.optionalWith({ default: () => "web" })
+  ),
+  notes: Schema.String.pipe(Schema.optional),
+});
+
+type OrderMetadata = typeof OrderMetadata.Type;
+
+// 2. Validate JSONB before INSERT
+const validateForInsert = (data: unknown) =>
+  Effect.gen(function* () {
+    const order = yield* Schema.decodeUnknown(OrderMetadata)(
+      data
+    ).pipe(
+      Effect.mapError((error) => ({
+        _tag: "InsertValidationError" as const,
+        message: `Order data invalid: ${error.message}`,
+      }))
+    );
+
+    // Additional business logic validation
+    if (order.items.length === 0) {
+      return yield* Effect.fail({
+        _tag: "BusinessLogicError" as const,
+        message: "Order must have at least one item",
+      });
+    }
+
+    return order;
+  });
+
+// 3. Validate JSONB after SELECT
+const validateFromPostgres = (
+  jsonbData: unknown
+) =>
+  Effect.gen(function* () {
+    const order = yield* Schema.decodeUnknown(OrderMetadata)(
+      jsonbData
+    ).pipe(
+      Effect.mapError((error) => ({
+        _tag: "SelectValidationError" as const,
+        message: `Retrieved JSONB invalid: ${error.message}`,
+      }))
+    );
+
+    return order;
+  });
+
+// 4. Handle PostgreSQL JSONB operators
+const queryOrdersByStatus = (status: string) =>
+  Effect.gen(function* () {
+    // Simulates: SELECT data FROM orders WHERE data->>'status' = ?
+    const mockDbResults: unknown[] = [
+      {
+        orderId: "ORD-001",
+        customerId: "CUST-123",
+        status: "shipped",
+        trackingNumber: "ABC123XYZ",
+        items: [
+          { productId: "PROD-1", quantity: 2, price: 29.99 },
+        ],
+        source: "web",
+      },
+      {
+        orderId: "ORD-002",
+        customerId: "CUST-456",
+        status: "shipped",
+        items: [
+          { productId: "PROD-2", quantity: 1, price: 49.99 },
+          { productId: "PROD-3", quantity: 3, price: 15.99 },
+        ],
+      },
+    ];
+
+    // Validate all results
+    const orders = yield* Effect.all(
+      mockDbResults.map((result) =>
+        validateFromPostgres(result)
+      )
+    );
+
+    return orders.filter((o) => o.status === status);
+  });
+
+// 5. Safe JSONB field extraction
+const extractOrderAmount = (
+  order: OrderMetadata
+): number => {
+  // Calculate from validated items (guaranteed to exist)
+  return order.items.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0
+  );
+};
+
+// 6. JSONB update pattern with validation
+const updateOrderStatus = (
+  orderId: string,
+  newStatus: OrderMetadata["status"],
+  trackingNumber?: string
+) =>
+  Effect.gen(function* () {
+    // Build JSONB update payload
+    const updatePayload: unknown = {
+      orderId,
+      status: newStatus,
+      ...(trackingNumber && {
+        trackingNumber,
+      }),
+    };
+
+    // Validate before sending to DB
+    const validated = yield* Schema.decodeUnknown(
+      Schema.Struct({
+        orderId: Schema.String,
+        status: OrderMetadata.fields.status,
+        trackingNumber: Schema.String.pipe(Schema.optional),
+      })
+    )(updatePayload);
+
+    // Simulates: UPDATE orders SET data = jsonb_set(data, ...)
+    console.log(`✅ Would update order with:`, validated);
+
+    return validated;
+  });
+
+// 7. Usage
+Effect.runPromise(
+  Effect.gen(function* () {
+    console.log("📦 PostgreSQL JSONB Validation\n");
+
+    // Query by status
+    const shippedOrders = yield* queryOrdersByStatus(
+      "shipped"
+    );
+    console.log(
+      `✅ Found ${shippedOrders.length} shipped orders`
+    );
+
+    for (const order of shippedOrders) {
+      const amount = extractOrderAmount(order);
+      console.log(
+        `  Order ${order.orderId}: $${amount.toFixed(2)}`
+      );
+    }
+
+    // Update order status
+    yield* updateOrderStatus(
+      "ORD-001",
+      "delivered",
+      "ABC123XYZ-DELIVERED"
+    );
+
+    // Insert new order
+    const newOrder = yield* validateForInsert({
+      orderId: "ORD-999",
+      customerId: "CUST-789",
+      status: "pending",
+      items: [
+        { productId: "PROD-X", quantity: 1, price: 99.99 },
+      ],
+    });
+
+    console.log(`✅ New order validated: ${newOrder.orderId}`);
+  })
+)
+  .catch((error) => {
+    console.error(`❌ ${error._tag}: ${error.message}`);
+  });
+```
+
+# Why This Works
+
+| Concept | Explanation |
+|---------|-------------|
+| Pre-INSERT validation | Catch bad data before it hits the database |
+| Post-SELECT validation | Ensure retrieved data hasn't corrupted |
+| JSONB operators awareness | Schema works with `->`, `->>`, `@>` queries |
+| Nested structure support | Array of items validated automatically |
+| Type-safe field access | No manual `data.items?.[0]?.price` checks |
+| Defaults for optional | Missing fields get sensible defaults |
+| Business logic validation | Schema validates format, code validates logic |
+
+# When to Use
+
+- PostgreSQL databases with JSONB columns
+- Order/invoice systems storing metadata as JSONB
+- Audit logs or event tracking in JSONB
+- Document stores on top of PostgreSQL
+- Flexible data that still needs type safety
+- Multi-tenant systems with per-tenant JSONB config
+- Before INSERT/UPDATE to prevent bad data
+- After SELECT to ensure consistency
+- JSONB query result validation
+
+# Related Patterns
+
+- [Validating JSON Database Columns](./basic.md)
+- [Handling Schema Evolution](./schema-evolution.md)
+- [Validating Partial Documents](./partial-validation.md)
+- [Basic JSON File Validation](../json-file-validation/basic.md)


### PR DESCRIPTION
## Summary

Add 4 new patterns for JSON validation in database contexts using Effect.Schema:

- **basic.md** (beginner): Validating JSON columns from database queries
- **postgres-jsonb.md** (intermediate): PostgreSQL JSONB-specific patterns
- **schema-evolution.md** (intermediate): Handling schema versioning and migration
- **partial-validation.md** (intermediate): PATCH operations with partial document validation

## Patterns

| Pattern | Skill | Focus |
|---------|-------|-------|
| Validating JSON Database Columns | beginner | Reading/validating from DB with defaults |
| PostgreSQL JSONB Validation | intermediate | JSONB operators, pre-INSERT/post-SELECT |
| Handling Schema Evolution | intermediate | Version detection, field mapping, migrations |
| Validating Partial Documents | intermediate | Schema.partial for PATCH operations |

## Test Results

✅ TypeScript check: passed (2163ms)
✅ All sections present: Problem, Solution, Why, When, Related
✅ Code examples type-check with Effect 3.x
✅ All required tags included

## Files Changed

- patterns/schema/json-db-validation/basic.md (168 lines)
- patterns/schema/json-db-validation/postgres-jsonb.md (255 lines)
- patterns/schema/json-db-validation/schema-evolution.md (304 lines)
- patterns/schema/json-db-validation/partial-validation.md (301 lines)

Total: 1,028 lines across 4 patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)