### PR TITLE
PR-1: OAuth/session security hardening (P0)

### DIFF
--- a/packages/mcp-server/src/auth/oauth-config.ts
+++ b/packages/mcp-server/src/auth/oauth-config.ts
@@ -80,7 +80,9 @@ export interface AuthenticatedSession {
     clientId: string;
     userId?: string;
     scopes: string[];
+    issuedAt: number;
     expiresAt: number;
+    refreshTokenExpiresAt?: number;
     accessToken: string;
     refreshToken?: string;
 }

--- a/packages/mcp-server/src/mcp-streamable-http.ts
+++ b/packages/mcp-server/src/mcp-streamable-http.ts
@@ -30,6 +30,20 @@ import { OAuthConfig } from "./auth/oauth-config.js";
 import { OAuth2Server } from "./auth/oauth-server.js";
 import { registerTools } from "./tools/tool-implementations.js";
 
+function getPositiveIntEnv(name: string, fallback: number): number {
+    const raw = process.env[name];
+    if (!raw) {
+        return fallback;
+    }
+
+    const parsed = parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        return fallback;
+    }
+
+    return parsed;
+}
+
 // ============================================================================
 // Configuration
 // ============================================================================
@@ -65,6 +79,23 @@ const SSE_DROP_AFTER_MS = parseInt(
     10,
 );
 const REQUEST_TIMEOUT_MS = 10000; // 10 seconds timeout
+const OAUTH_MAX_SESSIONS = getPositiveIntEnv("MCP_OAUTH_MAX_SESSIONS", 5000);
+const OAUTH_MAX_AUTH_CODES = getPositiveIntEnv(
+    "MCP_OAUTH_MAX_AUTH_CODES",
+    5000,
+);
+const OAUTH_CLEANUP_INTERVAL_MS = getPositiveIntEnv(
+    "MCP_OAUTH_CLEANUP_INTERVAL_MS",
+    60_000,
+);
+const EVENT_STORE_MAX_EVENTS = getPositiveIntEnv(
+    "MCP_EVENT_STORE_MAX_EVENTS",
+    2000,
+);
+const EVENT_STORE_TTL_MS = getPositiveIntEnv(
+    "MCP_EVENT_STORE_TTL_MS",
+    15 * 60 * 1000,
+);
 
 // OAuth 2.1 Configuration
 const oauthConfig: OAuthConfig = {
@@ -111,20 +142,45 @@ type StoredEvent = {
     eventId: string;
     streamId: string;
     message: unknown;
+    createdAt: number;
 };
 
 class InMemoryEventStore {
     private events: StoredEvent[] = [];
     private counter = 0;
 
+    constructor(
+        private readonly maxEvents: number,
+        private readonly eventTtlMs: number,
+    ) {}
+
+    private cleanupExpiredEvents(now: number): void {
+        const cutoff = now - this.eventTtlMs;
+        while (this.events.length > 0 && this.events[0]!.createdAt < cutoff) {
+            this.events.shift();
+        }
+    }
+
+    private enforceSizeLimit(): void {
+        if (this.events.length <= this.maxEvents) {
+            return;
+        }
+        const overflow = this.events.length - this.maxEvents;
+        this.events.splice(0, overflow);
+    }
+
     async storeEvent(streamId: string, message: unknown): Promise<string> {
+        const now = Date.now();
+        this.cleanupExpiredEvents(now);
         const eventId = String(++this.counter);
-        this.events.push({ eventId, streamId, message });
+        this.events.push({ eventId, streamId, message, createdAt: now });
+        this.enforceSizeLimit();
         log("Event stored", { streamId, eventId });
         return eventId;
     }
 
     async getStreamIdForEventId(eventId: string): Promise<string | undefined> {
+        this.cleanupExpiredEvents(Date.now());
         const found = this.events.find((e) => e.eventId === eventId);
         return found?.streamId;
     }
@@ -134,6 +190,7 @@ class InMemoryEventStore {
         { send }: { send: (eventId: string, message: unknown) => Promise<void> },
     ): Promise<string> {
         log("Replay requested", { lastEventId });
+        this.cleanupExpiredEvents(Date.now());
         const startIndex = this.events.findIndex((e) => e.eventId === lastEventId);
         if (startIndex === -1) {
             throw new Error("Unknown eventId");
@@ -631,13 +688,20 @@ async function main() {
 
     try {
         // Initialize OAuth 2.1 server
-        const oauthServer = new OAuth2Server(oauthConfig);
+        const oauthServer = new OAuth2Server(oauthConfig, {
+            maxSessions: OAUTH_MAX_SESSIONS,
+            maxAuthorizationCodes: OAUTH_MAX_AUTH_CODES,
+            cleanupIntervalMs: OAUTH_CLEANUP_INTERVAL_MS,
+        });
 
         // Create Streamable HTTP transport with session management
         const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(), // Enable stateful mode
             enableJsonResponse: false, // Use SSE streaming for better MCP 2.0 support
-            eventStore: new InMemoryEventStore(), // Enable resumption within this process
+            eventStore: new InMemoryEventStore(
+                EVENT_STORE_MAX_EVENTS,
+                EVENT_STORE_TTL_MS,
+            ), // Enable bounded resumption within this process
             onsessioninitialized: (sessionId) => {
                 log("Session initialized", { sessionId });
             },


### PR DESCRIPTION
## Summary
- enforce refresh-token expiry during refresh grant and revoke expired refresh sessions
- invalidate old access tokens on refresh-token rotation
- add bounded cleanup for OAuth sessions + authorization codes (size caps + periodic expiry sweeps)
- add bounded TTL cleanup for stream event store in streamable HTTP transport
- add auth tests for token rotation invalidation and refresh-token expiry rejection

## Files
- packages/mcp-server/src/auth/oauth-config.ts
- packages/mcp-server/src/auth/oauth-server.ts
- packages/mcp-server/src/mcp-streamable-http.ts
- packages/mcp-server/src/auth/__tests__/oauth-server.test.ts

## Gate
- bun run test:auth (packages/mcp-server): pass (47/47)
- bun run typecheck (packages/mcp-server): pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/token issuance and validation logic, so mistakes could cause unintended logouts or refresh failures. Changes are localized and covered by new unit tests plus configurable limits to reduce operational risk.
> 
> **Overview**
> **OAuth token/session hardening:** `OAuth2Server` now tracks `issuedAt` and optional `refreshTokenExpiresAt`, enforces refresh-token expiry, and *invalidates old access tokens on refresh* by revoking all sessions tied to the refresh token and deleting stale aliases during validation/cleanup.
> 
> **Memory/state bounding:** Adds periodic expiry sweeps plus size caps for in-memory OAuth sessions and authorization codes (configurable via new env vars in `mcp-streamable-http.ts`), and makes the streamable HTTP in-memory event store bounded by TTL and max events. Adds tests covering refresh rotation invalidation and refresh-token expiry rejection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ab4299599ca2084e904d282594eb0ca631f0442. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->