### PR TITLE
PR-5: Release test/CI repair (P1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,8 +239,8 @@ jobs:
           PATTERN_API_KEY: test-api-key-for-ci
           TEST_BASE_URL: http://localhost:3000
 
-      - name: Run MCP protocol tests
-        run: bun --filter @effect-patterns/mcp-server run test:mcp:local
+      - name: Run MCP protocol tests (tool surface + structured output)
+        run: bun --filter @effect-patterns/mcp-server run test:mcp:ci
         env:
           PATTERN_API_KEY: test-api-key-for-ci
           MCP_ENV: local

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -34,7 +34,8 @@
     "test:stress:all": "bun run test:stress",
     "test:mcp": "bunx vitest run --config vitest.mcp.config.ts",
     "test:mcp:watch": "bunx vitest --config vitest.mcp.config.ts",
-    "test:mcp:local": "MCP_ENV=local bunx vitest run --config vitest.mcp.config.ts tests/mcp-protocol/local.test.ts tests/mcp-protocol/stdio-discipline.test.ts",
+    "test:mcp:local": "MCP_ENV=local bunx vitest run --config vitest.mcp.config.ts tests/mcp-protocol/local.test.ts tests/mcp-protocol/structured-output.test.ts tests/mcp-protocol/stdio-discipline.test.ts",
+    "test:mcp:ci": "MCP_ENV=local bunx vitest run --config vitest.mcp.config.ts tests/mcp-protocol/local.test.ts tests/mcp-protocol/structured-output.test.ts tests/mcp-protocol/stdio-discipline.test.ts",
     "test:mcp:staging": "bash scripts/test-mcp-staging.sh",
     "test:mcp:production": "bash scripts/test-mcp-production.sh",
     "test:mcp:all": "bash scripts/test-mcp-all.sh",
@@ -54,7 +55,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "next lint",
     "check:narration-leakage": "bash scripts/check-narration-leakage.sh",
-    "preflight": "bun run mcp:build && bun run check:narration-leakage && bun run test:mcp:local"
+    "preflight": "bun run mcp:build && bun run check:narration-leakage && bun run test:mcp:ci"
   },
   "dependencies": {
     "@effect-patterns/analysis-core": "workspace:*",

--- a/packages/mcp-server/scripts/test-mcp-production.sh
+++ b/packages/mcp-server/scripts/test-mcp-production.sh
@@ -52,6 +52,8 @@ export EFFECT_PATTERNS_API_URL="${PRODUCTION_URL}"
 echo -e "${BLUE}Running MCP protocol tests against production server...${NC}\n"
 
 # Run MCP tests with production config
-bunx vitest run --config vitest.mcp.config.ts tests/mcp-protocol/client-stdio.test.ts tests/mcp-protocol/tools.test.ts
+bunx vitest run --config vitest.mcp.config.ts \
+    tests/mcp-protocol/client-stdio.test.ts \
+    tests/mcp-protocol/structured-output.test.ts
 
 echo -e "\n${GREEN}✓ Production MCP tests completed${NC}"

--- a/packages/mcp-server/scripts/test-mcp-staging.sh
+++ b/packages/mcp-server/scripts/test-mcp-staging.sh
@@ -52,6 +52,8 @@ export EFFECT_PATTERNS_API_URL="${STAGING_URL}"
 echo -e "${BLUE}Running MCP protocol tests against staging server...${NC}\n"
 
 # Run MCP tests with staging config
-bunx vitest run --config vitest.mcp.config.ts tests/mcp-protocol/client-stdio.test.ts tests/mcp-protocol/tools.test.ts
+bunx vitest run --config vitest.mcp.config.ts \
+    tests/mcp-protocol/client-stdio.test.ts \
+    tests/mcp-protocol/structured-output.test.ts
 
 echo -e "\n${GREEN}✓ Staging MCP tests completed${NC}"


### PR DESCRIPTION
Summary:
- replaced stale tools.test.ts references in staging/production MCP test scripts
- expanded local preflight/CI MCP test suite to include tool-surface and structured-output coverage
- updated CI MCP step to run the explicit MCP CI target

Scope:
- packages/mcp-server/scripts/test-mcp-staging.sh
- packages/mcp-server/scripts/test-mcp-production.sh
- packages/mcp-server/package.json
- .github/workflows/ci.yml

Changes:
- test-mcp-staging.sh now runs client-stdio.test.ts and structured-output.test.ts
- test-mcp-production.sh now runs client-stdio.test.ts and structured-output.test.ts
- package.json: expanded test:mcp:local, added test:mcp:ci, updated preflight to use test:mcp:ci
- ci.yml: MCP protocol step now runs bun --filter @effect-patterns/mcp-server run test:mcp:ci

Gate:
- bun run test:mcp:ci in packages/mcp-server passed (27/27)
- no remaining tools.test.ts references in scripts/package/CI

Note:
- full staging/production script execution requires STAGING_API_KEY and PRODUCTION_API_KEY, not present in this local environment. scripts were invoked and correctly enforce required-key checks.