### PR TITLE
PR-6: Performance + operational cleanup (P2)

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -272,7 +272,7 @@ Returns service health status (no authentication required).
 ```json
 {
   "ok": true,
-  "version": "0.5.1",
+  "version": "0.7.7",
   "service": "effect-patterns-mcp-server",
   "timestamp": "2024-01-13T12:00:00.000Z"
 }

--- a/packages/mcp-server/app/api/health/route.ts
+++ b/packages/mcp-server/app/api/health/route.ts
@@ -11,6 +11,9 @@
 import { randomUUID } from "node:crypto";
 import { NextResponse } from "next/server";
 
+const SERVICE_NAME = "effect-patterns-mcp-server";
+const SERVICE_VERSION = "0.7.7";
+
 export async function GET() {
   try {
     // Generate a trace ID for this request
@@ -19,8 +22,8 @@ export async function GET() {
     // Simple synchronous health check - no external dependencies
     const result = {
       ok: true,
-      version: "0.5.0",
-      service: "effect-patterns-mcp-server",
+      version: SERVICE_VERSION,
+      service: SERVICE_NAME,
       timestamp: new Date().toISOString(),
       traceId,
     };
@@ -40,8 +43,8 @@ export async function GET() {
       {
         ok: false,
         error: String(error),
-        version: "0.5.0",
-        service: "effect-patterns-mcp-server",
+        version: SERVICE_VERSION,
+        service: SERVICE_NAME,
         timestamp: new Date().toISOString(),
         traceId,
       },

--- a/packages/mcp-server/app/api/skills/[slug]/route.ts
+++ b/packages/mcp-server/app/api/skills/[slug]/route.ts
@@ -8,11 +8,12 @@
 import { getSkillBySlugDb } from "@effect-patterns/toolkit";
 import { Effect } from "effect";
 import { type NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
 import {
     validateApiKey,
 } from "../../../../src/auth/apiKey";
 import { SkillNotFoundError } from "../../../../src/errors";
-import { errorHandler } from "../../../../src/server/errorHandler";
+import { errorHandler, errorToResponse } from "../../../../src/server/errorHandler";
 import { runWithRuntime } from "../../../../src/server/init";
 import { TracingService } from "../../../../src/tracing/otlpLayer";
 
@@ -66,7 +67,9 @@ export async function GET(
       },
     });
   } catch (error) {
-    const errorResponse = await runWithRuntime(errorHandler(error));
-    return errorResponse;
+    // Runtime init or unexpected failure: avoid runWithRuntime (may fail again).
+    // Use errorToResponse directly; no Effect runtime required.
+    const traceId = randomUUID().replace(/-/g, "");
+    return errorToResponse(error, traceId);
   }
 }

--- a/packages/mcp-server/src/mcp-production-client.ts
+++ b/packages/mcp-server/src/mcp-production-client.ts
@@ -17,6 +17,7 @@ import { Agent as HttpsAgent } from "https";
 const PRODUCTION_URL = "https://effect-patterns-mcp.vercel.app";
 const API_KEY = process.env.PATTERN_API_KEY || process.env.PRODUCTION_API_KEY;
 const REQUEST_TIMEOUT_MS = 30000;
+const MCP_SERVER_VERSION = "2.0.0";
 
 // HTTP Connection Pooling (production API is always HTTPS)
 const httpsAgent = new HttpsAgent({
@@ -39,7 +40,7 @@ const inFlightRequests = new Map<
 const server = new McpServer(
     {
         name: "effect-patterns-production",
-        version: "1.0.0",
+        version: MCP_SERVER_VERSION,
     },
     {
         capabilities: {

--- a/packages/mcp-server/src/mcp-stdio.ts
+++ b/packages/mcp-server/src/mcp-stdio.ts
@@ -495,6 +495,7 @@ class SimpleCache {
 }
 
 const toolCache = new SimpleCache();
+const MCP_SERVER_VERSION = "2.0.0";
 
 // ============================================================================
 // MCP Server Setup
@@ -503,7 +504,7 @@ const toolCache = new SimpleCache();
 const server = new McpServer(
   {
     name: "effect-patterns",
-    version: "1.0.0",
+    version: MCP_SERVER_VERSION,
   },
   {
     capabilities: {


### PR DESCRIPTION
Summary:
- removed avoidable search N+1 detail fetches by rendering cards directly from rich search summaries when example/use-case data is already present
- sanitized 500 responses to avoid leaking DB/internal diagnostics unless MCP_DEBUG=true
- fixed catch-path runtime recursion risk in detail routes by using direct errorToResponse fallback
- normalized stale service/version strings across health endpoint, stdio/production MCP entrypoints, and README health sample

Scope:
- packages/mcp-server/src/tools/tool-result-builder.ts
- packages/mcp-server/src/server/errorHandler.ts
- packages/mcp-server/app/api/patterns/[id]/route.ts
- packages/mcp-server/app/api/skills/[slug]/route.ts
- packages/mcp-server/app/api/health/route.ts
- packages/mcp-server/src/mcp-stdio.ts
- packages/mcp-server/src/mcp-production-client.ts
- packages/mcp-server/README.md

Key changes:
1) Search performance cleanup
- tool-result-builder now renders from search summary data when examples are present
- detail endpoint call is now fallback-only for incomplete summaries

2) 500 response sanitization
- generic 500 error text unless MCP_DEBUG=true
- internal DB/error fields only included in debug mode

3) Detail route catch safety
- patterns/:id and skills/:slug catch blocks no longer call runWithRuntime(errorHandler(error))
- direct errorToResponse used to prevent recursion risk if runtime init fails

4) Version metadata normalization
- health route version updated to 0.7.7 and centralized in constants
- stdio and production MCP entrypoint server versions normalized to 2.0.0
- README health response sample updated from stale version

Gate:
- bun run test:routes passed (137/137)
- bunx vitest run --config vitest.mcp.config.ts tests/mcp-protocol/structured-output.test.ts passed (11/11)
- bunx vitest run src/tools/__tests__/structured-output.test.ts src/tools/__tests__/rendered-card-ids.test.ts passed (10/10)
- bun run typecheck passed