### PR TITLE
ci: harden vercel monorepo build config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,8 @@
-{"$schema": "https://openapi.vercel.sh/vercel.json", "bunVersion": "1.x", "framework": "nextjs", "buildCommand": "bun run --filter @effect-patterns/mcp-server build", "outputDirectory": "packages/mcp-server/.next", "regions": ["iad1"]}
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "bunVersion": "1.x",
+  "framework": "nextjs",
+  "buildCommand": "if [ -d packages/mcp-server ]; then cd packages/mcp-server && bun run build && rm -rf ../../.next && cp -R .next ../../.next; else bun run build; fi",
+  "outputDirectory": ".next",
+  "regions": ["iad1"]
+}


### PR DESCRIPTION
## Summary
- make root `vercel.json` build command work from either repository root or package root
- normalize output directory to `.next` for both execution modes
- keep existing package-level `packages/mcp-server/vercel.json` untouched

## Why
Recent Vercel checks are failing across multiple linked projects with deployment failures. The previous root config assumed root execution and used a filter-based build command that can fail when Vercel runs with a package root.

This makes the root config robust for both contexts.

## Validation
- ran the new root build command from repo root (success)
- ran the same command from `packages/mcp-server` (success)
- existing CI and MCP integration checks are already green on previous commits