### PR TITLE
ops: disable automatic Vercel git deployments

### DIFF
--- a/packages/mcp-server/vercel.json
+++ b/packages/mcp-server/vercel.json
@@ -1,1 +1,9 @@
-{"$schema": "https://openapi.vercel.sh/vercel.json", "bunVersion": "1.x", "framework": "nextjs", "buildCommand": "bun run build", "outputDirectory": ".next", "regions": ["iad1"]}
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "bunVersion": "1.x",
+  "framework": "nextjs",
+  "ignoreCommand": "echo 'Automatic Vercel git deployments are disabled for this repository.' && exit 0",
+  "buildCommand": "bun run build",
+  "outputDirectory": ".next",
+  "regions": ["iad1"]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "bunVersion": "1.x",
   "framework": "nextjs",
+  "ignoreCommand": "echo 'Automatic Vercel git deployments are disabled for this repository.' && exit 0",
   "buildCommand": "if [ -d packages/mcp-server ]; then cd packages/mcp-server && bun run build && rm -rf ../../.next && cp -R .next ../../.next; else bun run build; fi",
   "outputDirectory": ".next",
   "regions": ["iad1"]


### PR DESCRIPTION
Summary:\n- disable automatic Vercel git-triggered deployments in root and MCP project configs\n- add ignoreCommand to vercel.json and packages/mcp-server/vercel.json\n\nThis stops Vercel from building/deploying automatically on Git pushes and PR updates.